### PR TITLE
tree-wide: Drop `rpm-ostree cleanup -m`

### DIFF
--- a/ansible-firewalld/Dockerfile
+++ b/ansible-firewalld/Dockerfile
@@ -10,5 +10,4 @@ ADD configure-firewall-playbook.yml .
 RUN rpm-ostree install firewalld ansible && \
     ansible-playbook configure-firewall-playbook.yml && \
     rpm -e ansible && \
-    rpm-ostree cleanup -m && \
     ostree container commit

--- a/replace-kernel/Dockerfile
+++ b/replace-kernel/Dockerfile
@@ -6,5 +6,4 @@ RUN rpm-ostree cliwrap install-to-root /
 RUN rpm-ostree override replace https://kojipkgs.fedoraproject.org/packages/kernel/5.17.11/300.fc36/x86_64/kernel-modules-5.17.11-300.fc36.x86_64.rpm \
     https://kojipkgs.fedoraproject.org/packages/kernel/5.17.11/300.fc36/x86_64/kernel-core-5.17.11-300.fc36.x86_64.rpm \
     https://kojipkgs.fedoraproject.org/packages/kernel/5.17.11/300.fc36/x86_64/kernel-5.17.11-300.fc36.x86_64.rpm && \
-    rpm-ostree cleanup -m && \
     ostree container commit

--- a/replace-systemd/Dockerfile
+++ b/replace-systemd/Dockerfile
@@ -1,4 +1,3 @@
 FROM quay.io/coreos-assembler/fcos:testing-devel
 RUN rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2022-0bbb402870 && \
-    rpm-ostree cleanup -m && \
     ostree container commit

--- a/rsyslog/Dockerfile
+++ b/rsyslog/Dockerfile
@@ -1,7 +1,6 @@
 # Install and configure rsyslog
 FROM quay.io/coreos-assembler/fcos:testing-devel
 RUN rpm-ostree install rsyslog && \
-    rpm-ostree cleanup -m && \
     ostree container commit
 ADD remote.conf /etc/rsyslog.d/remote.conf
 

--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -3,6 +3,6 @@
 # `tailscale up` via some other mechanism.
 FROM quay.io/coreos-assembler/fcos:testing-devel
 RUN cd /etc/yum.repos.d/ && curl -LO https://pkgs.tailscale.com/stable/fedora/tailscale.repo && \
-    rpm-ostree install tailscale && rpm-ostree cleanup -m && \
+    rpm-ostree install tailscale && \
     systemctl enable tailscaled && \
     ostree container commit

--- a/wifi/Dockerfile
+++ b/wifi/Dockerfile
@@ -1,7 +1,6 @@
 # Install wireless support along with a static configuration file.
 FROM quay.io/coreos-assembler/fcos:testing-devel
 RUN rpm-ostree install NetworkManager-wifi NetworkManager-wwan wpa_supplicant wireless-regdb && \
-    rpm-ostree cleanup -m && \
     ostree container commit
 # And also inject a configuration
 ADD ExampleCorpWifi.ini /etc/NetworkManager/system-connections/


### PR DESCRIPTION
This command just deletes content from `/var/cache`, but that's no longer needed since it's part of
https://github.com/ostreedev/ostree-rs-ext/pull/367