### PR TITLE
replace-kernel: rebuild initramfs when rpm-ostree is older than 2022.18

### DIFF
--- a/replace-kernel/Containerfile
+++ b/replace-kernel/Containerfile
@@ -2,9 +2,11 @@
 FROM quay.io/fedora/fedora-coreos:stable
 # Enable cliwrap.
 RUN rpm-ostree cliwrap install-to-root /
+# temporary workaround for: https://github.com/coreos/rpm-ostree/issues/4190
+ADD dracut_call.sh dracut_call.sh
 # Replace the kernel, kernel-core and kernel-modules packages.
-RUN rpm-ostree override replace https://kojipkgs.fedoraproject.org/packages/kernel/5.17.11/300.fc36/x86_64/kernel-modules-5.17.11-300.fc36.x86_64.rpm \
-    https://kojipkgs.fedoraproject.org/packages/kernel/5.17.11/300.fc36/x86_64/kernel-core-5.17.11-300.fc36.x86_64.rpm \
-    https://kojipkgs.fedoraproject.org/packages/kernel/5.17.11/300.fc36/x86_64/kernel-5.17.11-300.fc36.x86_64.rpm && \
-    rpm-ostree cleanup -m && \
+RUN rpm-ostree override replace https://kojipkgs.fedoraproject.org//packages/kernel/6.0.10/300.fc37/x86_64/kernel-6.0.10-300.fc37.x86_64.rpm \
+    https://kojipkgs.fedoraproject.org//packages/kernel/6.0.10/300.fc37/x86_64/kernel-core-6.0.10-300.fc37.x86_64.rpm \
+    https://kojipkgs.fedoraproject.org//packages/kernel/6.0.10/300.fc37/x86_64/kernel-modules-6.0.10-300.fc37.x86_64.rpm && \
+    rpm-ostree cleanup -m && ./dracut_call.sh \
     ostree container commit

--- a/replace-kernel/dracut_call.sh
+++ b/replace-kernel/dracut_call.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Temporary workaround for: https://github.com/coreos/rpm-ostree/issues/4190
+# This has been fixed on rpm-ostree 2022.18 and this script will be removed
+# once that version reaches the stable coreos stream.
+version=$(rpm-ostree --version | grep Version)
+if [[ "$version" == *"2023"* ]] || [[ "$version" == *"2022.18"* ]]; then
+    echo "Running rpm-ostree 2022.18 or newer.";
+else
+    echo "Running rpm-ostree 2022.17 or older, rebuilding the initramfs.";
+    kver=$(ls /lib/modules)
+    echo "Building initramfs for Kernel: $kver" 
+    /usr/libexec/rpm-ostree/wrapped/dracut --tmpdir /tmp/ --no-hostonly --kver $kver --reproducible \
+    -v --add ostree -f /tmp/initramfs2.img
+    mv /tmp/initramfs2.img /lib/modules/$kver/initramfs.img
+fi;
+


### PR DESCRIPTION
temporary workaround for https://github.com/coreos/rpm-ostree/issues/4190 while rpm-ostree 2022.18 hits CoreOS stable stream.