### PR TITLE
tree-wide: Drop rpm-ostree cleanup -m

### DIFF
--- a/ansible-firewalld/Containerfile
+++ b/ansible-firewalld/Containerfile
@@ -10,5 +10,4 @@ ADD configure-firewall-playbook.yml .
 RUN rpm-ostree install firewalld ansible && \
     ansible-playbook configure-firewall-playbook.yml && \
     rpm -e ansible && \
-    rpm-ostree cleanup -m && \
     ostree container commit

--- a/build-zfs-module/Containerfile
+++ b/build-zfs-module/Containerfile
@@ -33,5 +33,4 @@ COPY --from=builder /zfs/*.rpm /
 RUN rpm-ostree install /*.$(uname -p).rpm && \
     # we don't want any files on /var
     rm -rf /var/lib/pcp && \
-    rpm-ostree cleanup -m && \
     ostree container commit 

--- a/podman-next/Containerfile
+++ b/podman-next/Containerfile
@@ -10,8 +10,7 @@ COPY rhcontainerbot-podman-next-fedora.gpg /etc/pki/rpm-gpg/
 # Remove moby-engine, containerd, runc
 # Note: Currently does not result in a size reduction for the container image
 RUN rpm-ostree override replace --experimental --freeze \
-        --from repo="copr:copr.fedorainfracloud.org:rhcontainerbot:podman-next" \
-        aardvark-dns conmon crun netavark podman containers-common containers-common-extra && \
+    --from repo="copr:copr.fedorainfracloud.org:rhcontainerbot:podman-next" \
+    aardvark-dns conmon crun netavark podman containers-common containers-common-extra && \
     rpm-ostree override remove moby-engine containerd runc && \
-    rpm-ostree cleanup -m && \
     ostree container commit

--- a/replace-kernel/Containerfile
+++ b/replace-kernel/Containerfile
@@ -8,5 +8,5 @@ ADD dracut_call.sh dracut_call.sh
 RUN rpm-ostree override replace https://kojipkgs.fedoraproject.org//packages/kernel/6.0.10/300.fc37/x86_64/kernel-6.0.10-300.fc37.x86_64.rpm \
     https://kojipkgs.fedoraproject.org//packages/kernel/6.0.10/300.fc37/x86_64/kernel-core-6.0.10-300.fc37.x86_64.rpm \
     https://kojipkgs.fedoraproject.org//packages/kernel/6.0.10/300.fc37/x86_64/kernel-modules-6.0.10-300.fc37.x86_64.rpm && \
-    rpm-ostree cleanup -m && ./dracut_call.sh \
+    ./dracut_call.sh && \
     ostree container commit

--- a/replace-systemd/Containerfile
+++ b/replace-systemd/Containerfile
@@ -1,4 +1,3 @@
 FROM quay.io/fedora/fedora-coreos:stable
 RUN rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2022-0bbb402870 && \
-    rpm-ostree cleanup -m && \
     ostree container commit

--- a/replace-systemd/Containerfile
+++ b/replace-systemd/Containerfile
@@ -1,3 +1,5 @@
 FROM quay.io/fedora/fedora-coreos:stable
 RUN rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2022-0bbb402870 && \
+    #https://coreos.github.io/rpm-ostree/architecture-core/#content-in-var
+    rm -rf /var/lock /var/mail /var/lib/ /var/log /var/run && \
     ostree container commit

--- a/rsyslog/Containerfile
+++ b/rsyslog/Containerfile
@@ -1,7 +1,6 @@
 # Install and configure rsyslog
 FROM quay.io/fedora/fedora-coreos:stable
 RUN rpm-ostree install rsyslog && \
-    rpm-ostree cleanup -m && \
     ostree container commit
 ADD remote.conf /etc/rsyslog.d/remote.conf
 

--- a/tailscale/Containerfile
+++ b/tailscale/Containerfile
@@ -3,6 +3,6 @@
 # `tailscale up` via some other mechanism.
 FROM quay.io/fedora/fedora-coreos:stable
 RUN cd /etc/yum.repos.d/ && curl -LO https://pkgs.tailscale.com/stable/fedora/tailscale.repo && \
-    rpm-ostree install tailscale && rpm-ostree cleanup -m && \
+    rpm-ostree install tailscale && \
     systemctl enable tailscaled && \
     ostree container commit

--- a/wifi/Containerfile
+++ b/wifi/Containerfile
@@ -1,7 +1,6 @@
 # Install wireless support along with a static configuration file.
 FROM quay.io/fedora/fedora-coreos:stable
 RUN rpm-ostree install NetworkManager-wifi NetworkManager-wwan wpa_supplicant wireless-regdb && \
-    rpm-ostree cleanup -m && \
     ostree container commit
 # And also inject a config file.  This pattern of using the COPY command
 # to inject an "overlay" for /etc can easily be extended to add multiple


### PR DESCRIPTION
Supersedes https://github.com/coreos/layering-examples/pull/33

This command just deletes content from /var/cache, but that's no longer needed since it's part of
https://github.com/ostreedev/ostree-rs-ext/pull/367