### PR TITLE
inject-go-binary: Move service into `/usr`, statically enabled

### DIFF
--- a/inject-go-binary/Containerfile
+++ b/inject-go-binary/Containerfile
@@ -9,7 +9,8 @@ FROM quay.io/fedora/fedora-coreos:stable
 # Inject it into Fedora CoreOS
 COPY --from=builder /build/hello-world /usr/bin
 # And add our unit file
-ADD hello-world.service /etc/systemd/system/hello-world.service
+ADD hello-world.service /usr/lib/systemd/system/hello-world.service
+RUN ln -s ../hello-world.service /usr/lib/systemd/system/multi-user.target.wants
 # Also add strace; the `rm -rf /var/cache` is the equivalent of `yum clean all`.
 # For `ostree container commit`, see https://github.com/ostreedev/ostree-rs-ext/issues/159
 RUN rpm-ostree install strace && rm -rf /var/cache && \


### PR DESCRIPTION
A big deal about the move to custom containers is that user content is treated the same way as OS content.  We should encourage storing *custom* systemd units in `/usr` so that they also end up underneath the read-only bind mount too.

While we're here, also do the "static enablement" pattern to force the unit on, regardless of presets.  Because thinking about presets is just annoying and unnecessary really.  If I'm injecting my custom service, there's really *no* scenario where I want some other preset file to control its enablement.