### PR TITLE
Add two sub-directory `README.md`

### DIFF
--- a/ansible-firewalld/README.md
+++ b/ansible-firewalld/README.md
@@ -1,0 +1,13 @@
+# Running ansible in a container build for firewalling
+
+In this example, we:
+
+- Derive from the base image
+- Install `ansible`
+- Inject [a playbook](configure-firewall-playbook.yml) into the image
+- Run ansible as part of the build, using the upstream `firewalld` task
+- Remove `ansible` (we don't need it at runtime)
+
+There's nothing really specific to firewalling here; this example can
+be used as a reference for executing any arbitrary ansible playbook
+as part of a container image build.

--- a/rsyslog/README.md
+++ b/rsyslog/README.md
@@ -1,0 +1,7 @@
+# Installing and configuring rsyslog
+
+This example installs `rsyslog` *and* a [configuration file](remote.conf) for it.
+
+This is a simple example, but it's worth elaborating here that we are *transactionally binding*
+the configuration and code.  For example, if you want to update the `rsyslog` version *and*
+change the config file at the same time, that is applied transactionally.


### PR DESCRIPTION
A key value here is that one can directly sub-link to e.g. https://github.com/coreos/layering-examples/tree/main/ansible-firewalld and instead of seeing just a raw file list, we will see the contents of this README which helps explain things.