### PR TITLE
fix(build-zfs): Replace `uname -p` in script

### DIFF
--- a/build-zfs-module/Containerfile
+++ b/build-zfs-module/Containerfile
@@ -30,7 +30,7 @@ FROM quay.io/fedora/fedora-coreos:stable
 COPY --from=builder /zfs/*.rpm /
 # For the example we install all RPMS (debug, test, etc).
 # In real use cases probably just want the module rpm.
-RUN rpm-ostree install /*.$(uname -p).rpm && \
+RUN rpm-ostree install /*.$(rpm -qa kernel --queryformat '%{ARCH}').rpm && \
     # we don't want any files on /var
     rm -rf /var/lib/pcp && \
     ostree container commit 


### PR DESCRIPTION
`uname -p` is broken under F38 and returns "unknown". See https://bugzilla.redhat.com/show_bug.cgi?id=2121153.