### PR TITLE
build-zfs-module: Update builder to use f38

### DIFF
--- a/build-zfs-module/Containerfile
+++ b/build-zfs-module/Containerfile
@@ -1,6 +1,6 @@
 # Needs to be set to the Fedora version 
 # on CoreOS stable stream, as it is our base image.
-ARG BUILDER_VERSION=37
+ARG BUILDER_VERSION=38
 
 FROM quay.io/fedora/fedora-coreos:stable as kernel-query
 #We can't use the `uname -r` as it will pick up the host kernel version


### PR DESCRIPTION
CoreOS stable is now fedora 38, updating the default BUILDER_VERSION ARG value.