### PR TITLE
fix(bulid-zfs): run depmod

### DIFF
--- a/build-zfs-module/Containerfile
+++ b/build-zfs-module/Containerfile
@@ -31,6 +31,7 @@ COPY --from=builder /zfs/*.rpm /
 # For the example we install all RPMS (debug, test, etc).
 # In real use cases probably just want the module rpm.
 RUN rpm-ostree install /*.$(rpm -qa kernel --queryformat '%{ARCH}').rpm && \
+    depmod -a `rpm -qa kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}'` && \
     # we don't want any files on /var
     rm -rf /var/lib/pcp && \
     ostree container commit 


### PR DESCRIPTION
Since October, the zfs install does not seem to run depmod, resulting in a broken `modprobe zfs`. Not sure if the issue comes from FCOS or OpenZFS.